### PR TITLE
Added -p command line option to specify download path.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -110,19 +110,20 @@ def max_dl_choice():
                 max_dl_choice()
 
 
-def change_path():
+def change_path(new_path="", silent=False):
     """
     Changes the path for new wallpaper downloads
     """
-    global message
-    Red()
-    new_path = input(f"""
-                    {green}Enter the complete path to the new location.
-                    This is case sensivite. "Pics" and "pics" are different
-                    e.g. /home/user/Pictures\n
-                    Current path is: {pictures}\n{normal}
-                    {red}x{normal} : {blue}main settings{normal}
-                    >>> """)
+    if not new_path:
+        global message
+        Red()
+        new_path = input(f"""
+                        {green}Enter the complete path to the new location.
+                        This is case sensivite. "Pics" and "pics" are different
+                        e.g. /home/user/Pictures\n
+                        Current path is: {pictures}\n{normal}
+                        {red}x{normal} : {blue}main settings{normal}
+                        >>> """)
     if new_path == "x":
         main_settings()
         return
@@ -134,7 +135,8 @@ def change_path():
         set_settings()
         Red()
         # return
-    change_path()
+    if not silent:
+        change_path()
 
 
 def wall_selection():

--- a/start.py
+++ b/start.py
@@ -5,6 +5,7 @@ import os
 import configparser
 import fetch
 import wall_set
+import settings
 from menu import main_menu
 
 parser = argparse.ArgumentParser(
@@ -24,6 +25,8 @@ parser.add_argument("-R", "--any", action="store_true",
                     help="Sets a random wallpaper form all the downloads")
 parser.add_argument("-r", "--recent", action="store_true",
                     help="Sets a random wallpaper from recent downloads")
+parser.add_argument("-p", "--path", metavar="path",
+                    help="Sets the path where background pictures are downloaded")
 
 args = parser.parse_args()
 
@@ -39,6 +42,8 @@ d_limit = int(config['settings']['download_limit'])
 
 
 def main():
+    if args.path:
+        settings.change_path(args.path, True)
     if args.download:
         if args.limit:
             fetch.d_limit = int(args.limit)


### PR DESCRIPTION
Added -p command line option to specify download path. Confirmed working.

Achieved by adding -p to the parser and checking if its present. if no other options are specified it will still run the interactive mode. To work with this the function for changing the path was also updated with default arguments. if they are left default the function runs the same as before, if they are changed the function takes note and runs silently and without asking for input.

This is only one way of achieving this, if this doesn't match up to what you had in mind let me know and I can work it out a different way.